### PR TITLE
Corrects secret name

### DIFF
--- a/gcp/gcp-external-dns/README.md
+++ b/gcp/gcp-external-dns/README.md
@@ -36,7 +36,7 @@ provider: google
 # You'll need to create this secret containing your credentials.json
 google:
   project: "<insert project id here>"
-  serviceAccountSecret: "google-service-account"
+  serviceAccountSecret: "external-dns"
 
 ## List of domains that can be managed. Should be managed by Google Cloud DNS
 domainFilters: ["<fully.qualified.domain>"]


### PR DESCRIPTION
To be coherent with the code:

kubectl -n external-dns-gcp create secret \
    generic **external-dns** \
  --from-file=credentials.json=credentials.json
secret/external-dns created